### PR TITLE
BugFix: fixes for app name

### DIFF
--- a/src/dftracer/core/dftracer_main.cpp
+++ b/src/dftracer/core/dftracer_main.cpp
@@ -173,7 +173,8 @@ void dftracer::DFTracerCore::initialize(bool _bind, const char *_log_file,
             if (!has_extracted) {
               strcpy(exec_name, basename(exec_cmd + last_index));
               if (exec_name[0] != '-' && strstr(exec_name, "python") == NULL &&
-                  strstr(exec_name, "env") == NULL) {
+                  strstr(exec_name, "env") == NULL &&
+                  strstr(exec_name, "multiprocessing") == NULL) {
                 has_extracted = true;
                 DFTRACER_LOG_INFO("Extracted process_name %s", exec_name);
               }
@@ -187,8 +188,18 @@ void dftracer::DFTracerCore::initialize(bool _bind, const char *_log_file,
           }*/
           index++;
         }
+        if (!has_extracted) {
+          if (strstr(exec_name, "multiprocessing") != NULL) {
+            sprintf(exec_name, "DEFAULT-spawn");
+          } else {
+            sprintf(exec_name, "DEFAULT");
+          }
+        }
         exec_cmd[DFT_PATH_MAX - 1] = '\0';
         DFTRACER_LOG_DEBUG("Exec command line %s", exec_cmd);
+      }
+      if (_process_id != nullptr && *_process_id != -1) {
+        sprintf(exec_name, "%s-%lu", exec_name, df_getpid());
       }
       if (_log_file == nullptr) {
         DFTRACER_LOG_INFO("Extracted process_name %s", exec_name);


### PR DESCRIPTION
- [x] Includes pid when pid is passed to maintain unique pids.
- [x] Fixes app name for spawn for Python 3.12 which gives app name as `from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=8, pipe_handle=14)`