### PR TITLE
Bugfix: Hash overflow error only comes in Release of 13.3

### DIFF
--- a/dfanalyzer/main.py
+++ b/dfanalyzer/main.py
@@ -175,35 +175,23 @@ def load_objects(line, fn, time_granularity, time_approximate, condition_fn, loa
             if "tid" in val:
                 d["tid"] = val["tid"]
             if "args" in val and "hhash" in val["args"]:
-                if type(val["args"]["hhash"]) is str:
-                    d["hhash"] = int(val["args"]["hhash"],16)
-                else: 
-                    d["hhash"] = val["args"]["hhash"]
+                d["hhash"] = str(val["args"]["hhash"])
             if "M" == val["ph"]:
                 if d["name"] == "FH":
                     d["type"] = 1 # 1-> file hash
                     if "args" in val and "name" in val["args"] and "value" in val["args"]:
                         d["name"] = val["args"]["name"]
-                        if type(val["args"]["value"]) is str:
-                            d["hash"] = int(val["args"]["value"],16)
-                        else: 
-                            d["hash"] = val["args"]["value"]
+                        d["hash"] = str(val["args"]["value"])
                 elif d["name"] == "HH":
                     d["type"] = 2 # 2-> hostname hash
                     if "args" in val and "name" in val["args"] and "value" in val["args"]:
                         d["name"] = val["args"]["name"]
-                        if type(val["args"]["value"]) is str:
-                            d["hash"] = int(val["args"]["value"],16)
-                        else: 
-                            d["hash"] = val["args"]["value"]
+                        d["hash"] = str(val["args"]["value"])
                 elif d["name"] == "SH":
                     d["type"] = 3 # 3-> string hash
                     if "args" in val and "name" in val["args"] and "value" in val["args"]:
                         d["name"] = val["args"]["name"]
-                        if type(val["args"]["value"]) is str:
-                            d["hash"] = int(val["args"]["value"],16)
-                        else: 
-                            d["hash"] = val["args"]["value"]
+                        d["hash"] = str(val["args"]["value"])
                 elif d["name"] == "PR":
                     d["type"] = 5 # 5-> process metadata
                     if "args" in val and "name" in val["args"] and "value" in val["args"]:

--- a/include/dftracer/core/typedef.h
+++ b/include/dftracer/core/typedef.h
@@ -9,5 +9,5 @@ typedef unsigned long int ThreadID;
 typedef unsigned long int ProcessID;
 typedef char* EventNameType;
 typedef const char* ConstEventNameType;
-typedef unsigned long long HashType;
+typedef char* HashType;
 #endif  // DFTRACER_TYPEDEF_H

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ class CMakeBuild(build_ext):
 
         # Using this requires trailing slash for auto-detection & inclusion of
         # auxiliary "native" libs
-        build_type = os.environ.get("DFTRACER_BUILD_TYPE", "Releasesetup.py") # Setting this to release causes memory issues with GCC-13.
+        build_type = os.environ.get("DFTRACER_BUILD_TYPE", "Release") # Setting this to release causes memory issues with GCC-13.
         cmake_args += [f"-DCMAKE_BUILD_TYPE={build_type}"]
         enable_ftracing = os.environ.get("DFTRACER_ENABLE_FTRACING", "OFF")
         cmake_args += [f"-DDFTRACER_ENABLE_FTRACING={enable_ftracing}"]

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ class CMakeBuild(build_ext):
 
         # Using this requires trailing slash for auto-detection & inclusion of
         # auxiliary "native" libs
-        build_type = os.environ.get("DFTRACER_BUILD_TYPE", "Debug") # Setting this to release causes memory issues with GCC-13.
+        build_type = os.environ.get("DFTRACER_BUILD_TYPE", "Releasesetup.py") # Setting this to release causes memory issues with GCC-13.
         cmake_args += [f"-DCMAKE_BUILD_TYPE={build_type}"]
         enable_ftracing = os.environ.get("DFTRACER_ENABLE_FTRACING", "OFF")
         cmake_args += [f"-DDFTRACER_ENABLE_FTRACING={enable_ftracing}"]

--- a/src/dftracer/brahma/stdio.cpp
+++ b/src/dftracer/brahma/stdio.cpp
@@ -55,6 +55,7 @@ size_t brahma::STDIODFTracer::fread(void *ptr, size_t size, size_t count,
 size_t brahma::STDIODFTracer::fwrite(const void *ptr, size_t size, size_t count,
                                      FILE *fp) {
   auto handle = fwrite_brahma_handle;
+  (void) handle;
   BRAHMA_MAP_OR_FAIL(fwrite);
   DFT_LOGGER_START(fp);
   DFT_LOGGER_UPDATE(size);

--- a/src/dftracer/df_logger.h
+++ b/src/dftracer/df_logger.h
@@ -113,11 +113,11 @@ class DFTLogger {
   inline HashType get_hash(char *name) {
     uint8_t result[HASH_OUTPUT];
     md5String(name, result);
-    char* hash_str = (char*) malloc(HASH_OUTPUT*2 + 1);
-    for (int i = 0; i < HASH_OUTPUT; i+=2) {
+    char *hash_str = (char *)malloc(HASH_OUTPUT * 2 + 1);
+    for (int i = 0; i < HASH_OUTPUT; i += 2) {
       sprintf(hash_str + i, "%02x", result[i]);
     }
-    hash_str[HASH_OUTPUT*2] = '\0';
+    hash_str[HASH_OUTPUT * 2] = '\0';
     return hash_str;
   }
 
@@ -377,9 +377,8 @@ class DFTLogger {
         }
         fix_str(file, PATH_MAX);
         int current_index = this->enter_event();
-        this->writer->log_metadata(current_index, file,
-                                   hash, name,
-                                   this->process_id, tid, false);
+        this->writer->log_metadata(current_index, file, hash, name,
+                                   this->process_id, tid, true);
         this->exit_event();
       }
     }

--- a/src/dftracer/df_logger.h
+++ b/src/dftracer/df_logger.h
@@ -104,18 +104,21 @@ class DFTLogger {
     }
     this->is_init = true;
   }
-  ~DFTLogger() {}
+  ~DFTLogger() {
+    for (auto &hash : computed_hash) {
+      if (hash.second) free(hash.second);
+    }
+  }
 
   inline HashType get_hash(char *name) {
     uint8_t result[HASH_OUTPUT];
     md5String(name, result);
-    char hash_str[HASH_OUTPUT*2 + 1];
+    char* hash_str = (char*) malloc(HASH_OUTPUT*2 + 1);
     for (int i = 0; i < HASH_OUTPUT; i+=2) {
       sprintf(hash_str + i, "%02x", result[i]);
     }
-    hash_str[HASH_OUTPUT] = '\0';
-    HashType hash = std::stoull(hash_str, nullptr, 16);
-    return hash;
+    hash_str[HASH_OUTPUT*2] = '\0';
+    return hash_str;
   }
 
   inline void update_log_file(std::string log_file, std::string exec_name,
@@ -375,7 +378,7 @@ class DFTLogger {
         fix_str(file, PATH_MAX);
         int current_index = this->enter_event();
         this->writer->log_metadata(current_index, file,
-                                   std::to_string(hash).c_str(), name,
+                                   hash, name,
                                    this->process_id, tid, false);
         this->exit_event();
       }

--- a/src/dftracer/df_logger.h
+++ b/src/dftracer/df_logger.h
@@ -109,8 +109,8 @@ class DFTLogger {
   inline HashType get_hash(char *name) {
     uint8_t result[HASH_OUTPUT];
     md5String(name, result);
-    char hash_str[HASH_OUTPUT + 1];
-    for (int i = 0; i < HASH_OUTPUT; ++i) {
+    char hash_str[HASH_OUTPUT*2 + 1];
+    for (int i = 0; i < HASH_OUTPUT; i+=2) {
       sprintf(hash_str + i, "%02x", result[i]);
     }
     hash_str[HASH_OUTPUT] = '\0';

--- a/src/dftracer/writer/chrome_writer.cpp
+++ b/src/dftracer/writer/chrome_writer.cpp
@@ -186,8 +186,8 @@ void dftracer::ChromeWriter::convert_json(
         if (i < meta_size - 1) meta_stream << ",";
 
       } else if (item.second.type() == typeid(HashType)) {
-        meta_stream << "\"" << item.first
-                    << "\":" << std::any_cast<HashType>(item.second) << "";
+        meta_stream << "\"" << item.first << "\":\""
+                    << std::any_cast<HashType>(item.second) << "\"";
         if (i < meta_size - 1) meta_stream << ",";
 
       } else if (item.second.type() == typeid(long)) {

--- a/src/dftracer/writer/chrome_writer.cpp
+++ b/src/dftracer/writer/chrome_writer.cpp
@@ -219,7 +219,7 @@ void dftracer::ChromeWriter::convert_json(
       previous_index = current_index;
       auto written_size = sprintf(
           buffer.data() + current_index,
-          R"(%s{"id":%d,"name":"%s","cat":"%s","pid":%lu,"tid":%lu,"ts":%llu,"dur":%llu,"ph":"X","args":{"hhash":%llu%s}})",
+          R"(%s{"id":%d,"name":"%s","cat":"%s","pid":%lu,"tid":%lu,"ts":%llu,"dur":%llu,"ph":"X","args":{"hhash":"%s"%s}})",
           is_first_char, index, event_name, category, process_id, thread_id,
           start_time, duration, this->hostname_hash, all_stream.str().c_str());
       current_index += written_size;
@@ -260,13 +260,13 @@ void dftracer::ChromeWriter::convert_json_metadata(
     if (is_string) {
       written_size = sprintf(
           buffer.data() + current_index,
-          R"(%s{"id":%d,"name":"%s","cat":"dftracer","pid":%lu,"tid":%lu,"ph":"M","args":{"hhash":%llu,"name":"%s","value":"%s"}})",
+          R"(%s{"id":%d,"name":"%s","cat":"dftracer","pid":%lu,"tid":%lu,"ph":"M","args":{"hhash":"%s","name":"%s","value":"%s"}})",
           is_first_char, index, ph, process_id, thread_id, this->hostname_hash,
           name, value);
     } else {
       written_size = sprintf(
           buffer.data() + current_index,
-          R"(%s{"id":%d,"name":"%s","cat":"dftracer","pid":%lu,"tid":%lu,"ph":"M","args":{"hhash":%llu,"name":"%s","value":%s}})",
+          R"(%s{"id":%d,"name":"%s","cat":"dftracer","pid":%lu,"tid":%lu,"ph":"M","args":{"hhash":"%s","name":"%s","value":%s}})",
           is_first_char, index, ph, process_id, thread_id, this->hostname_hash,
           name, value);
     }


### PR DESCRIPTION
Bugfix: Hash overflow error only comes in Release of 13.3

The overflow causes due to 128 hash values converted to long long ints. Now we store as hash values.